### PR TITLE
workaround kubectl exec behaviour

### DIFF
--- a/envoy_stats.sh
+++ b/envoy_stats.sh
@@ -8,7 +8,7 @@ do
 	do 
 		#kubectl exec -it $pod  -c istio-proxy  -- sh -c 'curl localhost:15000/stats' | gzip > $pod.$d.gz
 		echo "Storing data for pod $pod"
-		kubectl exec -it $pod  -c istio-proxy  -- sh -c 'curl localhost:15000/stats' > $pod.$d
+		kubectl exec $pod  -c istio-proxy  -- sh -c 'curl localhost:15000/stats | grep 9080' > $pod.$d
 	done
 	sleep 5
 done


### PR DESCRIPTION
it turns it truncates output from the curl in interactive mode. looks
like it is not an issue without the mode. plus the app is interested
in 9080 port activities. let's pull them only with a simple grep
filter.