### PR TITLE
monitor may hang scanning the data folder or inside the anomalies

### DIFF
--- a/demo_inside_eks_sandbox.sh
+++ b/demo_inside_eks_sandbox.sh
@@ -447,8 +447,14 @@ function stop_monitor() {
 		rip "MY"
 
 		protect_monitor stop_monitor_
-
+		(
+			sleep 5
+			kill -s 9 $MX 2>/dev/null
+		) &
+		local k=$!
 		wait $MX 2>/dev/null
+		kill -s 9 $k 2>/dev/null
+
 		MX=0
 		MONITOR_CHANNEL=0
 	fi


### PR DESCRIPTION
detector. let's give it 5 seconds to quit and kill after the
timeout